### PR TITLE
feat: add pause menu button to game canvas

### DIFF
--- a/packages/web/src/ui/GameCanvas.start.test.tsx
+++ b/packages/web/src/ui/GameCanvas.start.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, beforeAll } from 'vitest';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { GameCanvas } from './GameCanvas';
 
 describe('GameCanvas start interaction', () => {
@@ -44,6 +44,21 @@ describe('GameCanvas start interaction', () => {
 
     await waitFor(() => {
       expect(screen.queryByLabelText('start-overlay')).toBeNull();
+    });
+  });
+
+  it('opens and closes the pause overlay via menu button', async () => {
+    render(<GameCanvas />);
+
+    const [menuButton] = screen.getAllByRole('button', { name: /open menu/i });
+    fireEvent.click(menuButton);
+
+    expect(await screen.findByLabelText('pause-overlay')).toBeTruthy();
+
+    fireEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('pause-overlay')).toBeNull();
     });
   });
 });

--- a/packages/web/src/ui/GameCanvas.tsx
+++ b/packages/web/src/ui/GameCanvas.tsx
@@ -17,6 +17,7 @@ import { NextQueue } from './NextQueue';
 import { HoldBox } from './HoldBox';
 import { GameOverOverlay } from './GameOverOverlay';
 import { StartOverlay } from './StartOverlay';
+import { MenuButton } from './MenuButton';
 import { EffectScheduler } from '../effects/Effects';
 import { initHighscores, maybeSubmit, getHighscores } from '../highscore';
 import { useAudio } from '../audio/AudioProvider';
@@ -61,6 +62,19 @@ function GameCanvasInner(): JSX.Element {
   const [started, setStarted] = React.useState(false);
   const { toasts, addToast } = useToastManager();
   const { settings } = useSettings();
+  const toggleMenu = React.useCallback(() => {
+    setPaused((prev) => {
+      const next = !prev;
+      if (next) {
+        hostRef.current?.setPaused(true);
+      } else {
+        setShowSettings(false);
+        setShowHelp(false);
+        if (started) hostRef.current?.setPaused(false);
+      }
+      return next;
+    });
+  }, [started]);
   const palette = React.useMemo(() => getPalette(settings.theme), [settings.theme]);
   const [nextIds, setNextIds] = React.useState<readonly import('@tetris/core').TetrominoId[]>([]);
   const [holdId, setHoldId] = React.useState<import('@tetris/core').TetrominoId | null>(null);
@@ -378,7 +392,21 @@ function GameCanvasInner(): JSX.Element {
     >
       <canvas ref={canvasRef} style={{ width: '100%', height: '100%' }} />
       <HUD score={score} level={level} lines={lines} pb={pb} />
-      <NextQueue next={nextIds} palette={palette} />
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          alignItems: 'flex-end',
+          zIndex: 5,
+        }}
+      >
+        <MenuButton open={paused} onToggle={toggleMenu} />
+        <NextQueue next={nextIds} palette={palette} style={{ position: 'static', marginTop: 0 }} />
+      </div>
       <HoldBox hold={holdId} canHold={canHold} palette={palette} />
       <StatusToasts toasts={toasts} />
       <StartOverlay visible={!started && !gameOver} />
@@ -387,8 +415,10 @@ function GameCanvasInner(): JSX.Element {
         onOpenSettings={() => setShowSettings(true)}
         onOpenHelp={() => setShowHelp(true)}
         onResume={() => {
+          setShowSettings(false);
+          setShowHelp(false);
           setPaused(false);
-          hostRef.current?.setPaused(false);
+          if (started) hostRef.current?.setPaused(false);
         }}
       />
       {showSettings ? <SettingsModal onClose={() => setShowSettings(false)} /> : null}

--- a/packages/web/src/ui/MenuButton.tsx
+++ b/packages/web/src/ui/MenuButton.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+/**
+ * MenuButton renders a floating action control that toggles the pause menu.
+ *
+ * The button matches the translucent panel styling used across overlays and
+ * exposes an active state so callers can indicate when the menu is open.
+ */
+export function MenuButton(props: {
+  open: boolean;
+  onToggle?: () => void;
+}): JSX.Element {
+  const { open, onToggle } = props;
+  const container: React.CSSProperties = {
+    position: 'relative',
+    pointerEvents: 'auto',
+  };
+  const button: React.CSSProperties = {
+    appearance: 'none',
+    border: '1px solid #475569',
+    background: open ? '#475569' : '#334155',
+    color: 'var(--fg, #e2e8f0)',
+    padding: '8px 14px',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontSize: 13,
+    fontFamily:
+      'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial',
+    letterSpacing: 0.4,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
+    boxShadow: '0 4px 12px rgba(15,23,42,0.35)',
+    transition: 'background 120ms ease, transform 120ms ease',
+  };
+  const icon: React.CSSProperties = {
+    width: 18,
+    height: 12,
+    display: 'grid',
+    gap: 3,
+  };
+  const bar: React.CSSProperties = {
+    width: '100%',
+    height: 2,
+    borderRadius: 2,
+    background: 'currentColor',
+    opacity: open ? 1 : 0.9,
+  };
+
+  return (
+    <div style={container}>
+      <button
+        type="button"
+        style={button}
+        onClick={onToggle}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+        }}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
+        aria-pressed={open}
+        aria-label={open ? 'Close menu' : 'Open menu'}
+      >
+        <span aria-hidden="true" style={icon}>
+          <span style={bar} />
+          <span style={bar} />
+          <span style={bar} />
+        </span>
+        <span>Menu</span>
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/ui/NextQueue.tsx
+++ b/packages/web/src/ui/NextQueue.tsx
@@ -6,7 +6,15 @@ import { PiecePreview } from './PiecePreview';
 /**
  * NextQueue renders a vertical list of upcoming tetromino previews.
  */
-export function NextQueue({ next, palette }: { next: readonly TetrominoId[]; palette: Palette }): JSX.Element {
+export function NextQueue({
+  next,
+  palette,
+  style,
+}: {
+  next: readonly TetrominoId[];
+  palette: Palette;
+  style?: React.CSSProperties;
+}): JSX.Element {
   const wrap: React.CSSProperties = {
     position: 'absolute',
     right: 12,
@@ -21,7 +29,7 @@ export function NextQueue({ next, palette }: { next: readonly TetrominoId[]; pal
     alignItems: 'center',
   };
   return (
-    <div style={wrap} aria-label="next-queue">
+    <div style={{ ...wrap, ...style }} aria-label="next-queue">
       <div style={{ fontSize: 12, opacity: 0.8, marginBottom: 4 }}>NEXT</div>
       {next.map((id, idx) => (
         <PiecePreview key={`${id}-${idx}`} id={id} palette={palette} width={48} height={34} />


### PR DESCRIPTION
## Summary
- add a reusable MenuButton component that matches the existing overlay styling
- integrate the button into the game canvas to toggle the pause menu and adjust layout to keep the next queue aligned
- allow the next queue component to accept style overrides and extend start interaction tests for the new control

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f079eb24832da417dd12103c64cd